### PR TITLE
Add .dockerignore and update microservice transport config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.git
+.gitignore
+.env
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 .package-lock.json
+Dockerfile

--- a/src/centers/centers.gateway.module.ts
+++ b/src/centers/centers.gateway.module.ts
@@ -1,21 +1,37 @@
-import { Module } from '@nestjs/common';
-import { ClientsModule, Transport } from '@nestjs/microservices';
-
 import { CentersGatewayController } from './centers.gateway.controller';
 import { CentersRequestsGatewayController } from './centers.requests.gateway.controller';
+import { Module } from '@nestjs/common';
+import {
+  ClientsModule,
+  Transport,
+  ClientProviderOptions,
+} from '@nestjs/microservices';
+
+const MS_TRANSPORT = process.env.MS_TRANSPORT ?? 'TCP';
+const useTcp = MS_TRANSPORT === 'TCP';
+
+const host = process.env.CENTERS_HOST ?? 'centers';
+const port = Number(process.env.CENTERS_PORT ?? 4030);
+
+const CENTERS_CLIENT_TCP: ClientProviderOptions = {
+  name: 'CENTERS_MS',
+  transport: Transport.TCP,
+  options: { host, port },
+};
+
+const CENTERS_CLIENT_RMQ: ClientProviderOptions = {
+  name: 'CENTERS_MS',
+  transport: Transport.RMQ,
+  options: {
+    urls: [process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672'],
+    queue: 'centers_queue',
+    queueOptions: { durable: true },
+  },
+};
 
 @Module({
   imports: [
-    ClientsModule.register([
-      {
-        name: 'CENTERS_MS',
-        transport: Transport.TCP,
-        options: {
-          host: process.env.CENTERS_MS_HOST || '127.0.0.1',
-          port: Number(process.env.CENTERS_MS_PORT) || 4010,
-        },
-      },
-    ]),
+    ClientsModule.register([useTcp ? CENTERS_CLIENT_TCP : CENTERS_CLIENT_RMQ]),
   ],
   controllers: [CentersRequestsGatewayController, CentersGatewayController],
 })


### PR DESCRIPTION
Introduced a .dockerignore file to exclude unnecessary files from Docker builds. Updated .gitignore to ignore Dockerfile. Refactored centers.gateway.module.ts to dynamically select TCP or RMQ transport for microservice client based on environment variables, improving deployment flexibility.